### PR TITLE
CpuIdFactory: Simplify the interface

### DIFF
--- a/src/lib/cpuid/cpuid_factory.cpp
+++ b/src/lib/cpuid/cpuid_factory.cpp
@@ -6,47 +6,54 @@
 #include "cpuid/cpuid_native_config.h"
 #include "cpuid/cpuid_native.h"
 
-namespace rjcp::cpuid {
-
-template<>
-CpuIdFactory<CpuIdDefaultConfig>::CpuIdFactory() noexcept = default;
-
-template<>
-CpuIdFactory<CpuIdDefaultConfig>::CpuIdFactory(CpuIdDefaultConfig& /* config */) noexcept
+namespace rjcp::cpuid
 {
-    // There is no configuration.
+
+namespace
+{
+template <typename CreationCallback>
+class CpuIdFactoryWithCallback : public ICpuIdFactory
+{
+public:
+    CpuIdFactoryWithCallback(const CreationCallback &create_callback) : create_callback_{create_callback} {};
+
+    auto create(int cpunum) noexcept -> std::unique_ptr<ICpuId> override
+    {
+        return create_callback_(cpunum);
+    }
+
+private:
+    CreationCallback create_callback_;
+};
+
+template <typename CreationCallback>
+auto MakeCpuIdFactory(const CreationCallback &callback) -> std::unique_ptr<ICpuIdFactory>
+{
+    return std::make_unique<CpuIdFactoryWithCallback<CreationCallback>>(callback);
+}
+} // namespace
+
+// TODO: Consider extracting the CreateCpuIdFactory specializations into seperate translation units to decouple the concrete types.
+
+template <>
+auto CreateCpuIdFactory(const CpuIdDefaultConfig &) noexcept -> std::unique_ptr<ICpuIdFactory>
+{
+    return MakeCpuIdFactory([](int cpunum) -> std::unique_ptr<ICpuId>
+                            { return std::make_unique<CpuIdDefault>(cpunum); });
 }
 
-template<>
-auto CpuIdFactory<CpuIdDefaultConfig>::create(int cpunum) noexcept -> std::unique_ptr<ICpuId>
+template <>
+auto CreateCpuIdFactory(const CpuIdDeviceConfig &config) noexcept -> std::unique_ptr<ICpuIdFactory>
 {
-    return std::make_unique<CpuIdDefault>(cpunum);
+    return MakeCpuIdFactory([config](int cpunum) -> std::unique_ptr<ICpuId>
+                            { return std::make_unique<CpuIdDevice>(cpunum, config.method); });
 }
 
-template<>
-CpuIdFactory<CpuIdNativeConfig>::CpuIdFactory() noexcept = default;
-
-template<>
-CpuIdFactory<CpuIdNativeConfig>::CpuIdFactory(CpuIdNativeConfig& /* config */) noexcept
+template <>
+auto CreateCpuIdFactory(const CpuIdNativeConfig &) noexcept -> std::unique_ptr<ICpuIdFactory>
 {
-    // There is no configuration.
-}
-
-template<>
-auto CpuIdFactory<CpuIdNativeConfig>::create(int cpunum) noexcept -> std::unique_ptr<ICpuId>
-{
-    return std::make_unique<CpuIdNative>(cpunum);
-}
-
-CpuIdFactory<CpuIdDeviceConfig>::CpuIdFactory() noexcept = default;
-
-CpuIdFactory<CpuIdDeviceConfig>::CpuIdFactory(CpuIdDeviceConfig& config) noexcept
-    : m_method{config.method}
-{ }
-
-auto CpuIdFactory<CpuIdDeviceConfig>::create(int cpunum) noexcept -> std::unique_ptr<ICpuId>
-{
-    return std::make_unique<CpuIdDevice>(cpunum, m_method);
+    return MakeCpuIdFactory([](int cpunum) -> std::unique_ptr<ICpuId>
+                            { return std::make_unique<CpuIdNative>(cpunum); });
 }
 
 }

--- a/src/lib/cpuid/cpuid_factory.h
+++ b/src/lib/cpuid/cpuid_factory.h
@@ -11,46 +11,11 @@
 namespace rjcp::cpuid {
 
 /**
- * @brief Template class for factories creating objects of type ICpuId.
- *
- * @tparam T The configuration object, which is also used to choose the object
- * to build from the factory's create() method.
+ * @brief Function to instantiate a factory with a given factory config that serves as a blueprint.
+ * @param config The blueprint configuration object that determines which concrete type will be created.
  */
-template<typename T>
-class CpuIdFactory : public ICpuIdFactory
-{
-public:
-    CpuIdFactory() noexcept;
-
-    CpuIdFactory(T& config) noexcept;
-
-    /**
-     * @brief Create the default CPUID object.
-     *
-     * @param cpunum The CPU object to create for.
-     * @return ICpuId The CPUID object.
-     */
-    auto create(int cpunum) noexcept -> std::unique_ptr<ICpuId>;
-};
-
-/**
- * @brief Specialization for the CpuIdDeviceConfig
- *
- * @tparam
- */
-template<>
-class CpuIdFactory<CpuIdDeviceConfig> : public ICpuIdFactory
-{
-public:
-    CpuIdFactory() noexcept;
-
-    CpuIdFactory(CpuIdDeviceConfig& config) noexcept;
-
-    auto create(int cpunum) noexcept -> std::unique_ptr<ICpuId> override;
-
-private:
-    DeviceAccessMethod m_method{DeviceAccessMethod::seek};
-};
+template<typename Config>
+auto CreateCpuIdFactory(const Config& config) noexcept -> std::unique_ptr<ICpuIdFactory>;
 
 }
 

--- a/test/lib/cpuid/cpuid_factory_test.cpp
+++ b/test/lib/cpuid/cpuid_factory_test.cpp
@@ -31,48 +31,34 @@ static auto DumpRegisters(ICpuIdFactory& factory, bool isValid)
 
 TEST(CpuIdFactory, CpuIdDefault)
 {
-    CpuIdFactory<CpuIdDefaultConfig> factory{};
-    DumpRegisters(factory, false);
-}
-
-TEST(CpuIdFactory, CpuIdDefaultEmptyConfig)
-{
-    CpuIdDefaultConfig config{};
-    CpuIdFactory<CpuIdDefaultConfig> factory{config};
-    DumpRegisters(factory, false);
+    auto factory = CreateCpuIdFactory(CpuIdDefaultConfig{});
+    DumpRegisters(*factory, false);
 }
 
 TEST(CpuIdFactory, CpuIdNative)
 {
-    CpuIdFactory<CpuIdNativeConfig> factory{};
-    DumpRegisters(factory, true);
-}
-
-TEST(CpuIdFactory, CpuIdNativeEmptyConfig)
-{
-    CpuIdNativeConfig config{};
-    CpuIdFactory<CpuIdNativeConfig> factory{config};
-    DumpRegisters(factory, true);
+    auto factory = CreateCpuIdFactory(CpuIdNativeConfig{});
+    DumpRegisters(*factory, true);
 }
 
 TEST(CpuIdFactory, CpuIdDeviceDefault)
 {
-    CpuIdFactory<CpuIdDeviceConfig> factory{};
-    DumpRegisters(factory, true);
+    auto factory = CreateCpuIdFactory(CpuIdDeviceConfig{});
+    DumpRegisters(*factory, true);
 }
 
 TEST(CpuIdFactory, CpuIdDeviceSeek)
 {
     CpuIdDeviceConfig config{DeviceAccessMethod::seek};
-    CpuIdFactory<CpuIdDeviceConfig> factory{config};
-    DumpRegisters(factory, true);
+    auto factory = CreateCpuIdFactory(config);
+    DumpRegisters(*factory, true);
 }
 
 TEST(CpuIdFactory, CpuIdDevicePread)
 {
     CpuIdDeviceConfig config{DeviceAccessMethod::pread};
-    CpuIdFactory<CpuIdDeviceConfig> factory{config};
-    DumpRegisters(factory, true);
+    auto factory = CreateCpuIdFactory(config);
+    DumpRegisters(*factory, true);
 }
 
 }


### PR DESCRIPTION
The concrete CpuIdFactory does not need to be exposed in the header to the users. Instead a single templated free function would suffice to create a factory parameterized with the desired configuration object. This unclutters the header and avoids exposing unneeded dependencies in the header.

By introducing a helper class `CpuIdFactoryWithCallback` for each concrete factory we only need one specialization of the free function `CreateCpuIdFactory()`. Each specialization injects a callback in in the helper class that contains the actual creation logic and captures the configuration object.

Further refactoring could extract the concrete specializations of `CreateCpuIdFactory` into separate translation units. This would completely decouple the concrete types from each other, and save recompilation of all factories if just one concrete type is changed.